### PR TITLE
Lint Markdown files

### DIFF
--- a/.github/workflows/markdown.yml
+++ b/.github/workflows/markdown.yml
@@ -44,10 +44,23 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: markdownlint-cli
-        uses: nosborn/github-action-markdown-cli@v3.4.0
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
         with:
-          files: "**.md"
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install earthly
+        uses: earthly/actions-setup@v1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          version: 0.8
+
+      - name: Run check with Earthly
+        env:
+          EARTHLY_TOKEN: ${{ secrets.EARTHLY_TOKEN }}
+        run: earthly --ci --push --remote-cache=ghcr.io/jdno/earthly-functions-earthly-cache:lint-markdown +lint-markdown
 
   style:
     name: Check style

--- a/Earthfile
+++ b/Earthfile
@@ -1,0 +1,6 @@
+VERSION 0.8
+PROJECT jdno/earthly-functions
+
+# lint-markdown checks Markdown files for linting errors
+lint-markdown:
+    DO ./markdown+LINT

--- a/markdown/Earthfile
+++ b/markdown/Earthfile
@@ -1,0 +1,19 @@
+VERSION 0.8
+
+LINT:
+    FUNCTION
+
+    # Optionally specify the version of markdownlint-cli that gets used
+    ARG MARKDOWNLINT_VERSION="latest"
+
+    FROM node:alpine
+    WORKDIR /project
+
+    # Install the markdownlint-cli
+    RUN npm install -g markdownlint-cli@$MARKDOWNLINT_VERSION
+
+    # Copy the source code into the container
+    COPY . .
+
+    # Check the Markdown files for linting errors
+    RUN markdownlint **/*.md


### PR DESCRIPTION
A new Earthly target that lints Markdown files has been created. The target executes a function that can be used by other projects as well. The function installs the `markdownlint-cli` from npm, copies all files in the working directory into the container, and then runs the CLI on all Markdown files.

The version of `markdownlint-cli` can be passed as an argument to the function. In this repository, we are happy to use the latest version, but other projects might want to lock the version.