### PR TITLE
Lint YAML files

### DIFF
--- a/.github/workflows/yaml.yml
+++ b/.github/workflows/yaml.yml
@@ -45,8 +45,23 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Run yamllint
-        uses: actionshub/yamllint@v1.8.3
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install earthly
+        uses: earthly/actions-setup@v1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          version: 0.8
+
+      - name: Run check with Earthly
+        env:
+          EARTHLY_TOKEN: ${{ secrets.EARTHLY_TOKEN }}
+        run: earthly --ci --push --remote-cache=ghcr.io/jdno/earthly-functions-earthly-cache:lint-yaml +lint-yaml
 
   style:
     name: Check style

--- a/Earthfile
+++ b/Earthfile
@@ -4,3 +4,7 @@ PROJECT jdno/earthly-functions
 # lint-markdown checks Markdown files for linting errors
 lint-markdown:
     DO ./markdown+LINT
+
+# lint-yaml checks YAML files for linting errors
+lint-yaml:
+    DO ./yaml+LINT

--- a/yaml/Earthfile
+++ b/yaml/Earthfile
@@ -1,0 +1,16 @@
+VERSION 0.8
+
+LINT:
+    FUNCTION
+
+    # Optionally specify the version of yamllint that gets used
+    ARG YAMLLINT_VERSION="latest"
+
+    FROM pipelinecomponents/yamllint:$YAMLLINT_VERSION
+    WORKDIR /project
+
+    # Copy the source code into the container
+    COPY . .
+
+    # Check the YAML files for linting errors
+    RUN yamllint .


### PR DESCRIPTION
A new Earthly target that lints YAML files has been created. The target executes a function that can be used by other projects as well. The function pulls a Docker image with `yamllint`, copies all files in the directory into the container, and then runs `yamllint` on all YAML files.

The version of the `yamllint` image can be passed as an argument to the function. In this repository, we are happy to use the latest version, but other projects might want to lock the version.