### PR TITLE
Format files with Prettier

### DIFF
--- a/.github/workflows/json.yml
+++ b/.github/workflows/json.yml
@@ -44,8 +44,20 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: prettier
-        uses: creyD/prettier_action@v4.3
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
         with:
-          dry: true
-          prettier_options: "--check **/*.json"
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install earthly
+        uses: earthly/actions-setup@v1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          version: 0.8
+
+      - name: Run check with Earthly
+        env:
+          EARTHLY_TOKEN: ${{ secrets.EARTHLY_TOKEN }}
+        run: earthly --ci --push --remote-cache=ghcr.io/jdno/earthly-functions-earthly-cache:format-json +format-json

--- a/.github/workflows/markdown.yml
+++ b/.github/workflows/markdown.yml
@@ -73,8 +73,20 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: prettier
-        uses: creyD/prettier_action@v4.3
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
         with:
-          dry: true
-          prettier_options: "--check **/*.md"
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install earthly
+        uses: earthly/actions-setup@v1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          version: 0.8
+
+      - name: Run check with Earthly
+        env:
+          EARTHLY_TOKEN: ${{ secrets.EARTHLY_TOKEN }}
+        run: earthly --ci --push --remote-cache=ghcr.io/jdno/earthly-functions-earthly-cache:format-markdown +format-markdown

--- a/.github/workflows/yaml.yml
+++ b/.github/workflows/yaml.yml
@@ -74,8 +74,20 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: prettier
-        uses: creyD/prettier_action@v4.3
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
         with:
-          dry: true
-          prettier_options: "--check **/*.{yml,yaml}"
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install earthly
+        uses: earthly/actions-setup@v1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          version: 0.8
+
+      - name: Run check with Earthly
+        env:
+          EARTHLY_TOKEN: ${{ secrets.EARTHLY_TOKEN }}
+        run: earthly --ci --push --remote-cache=ghcr.io/jdno/earthly-functions-earthly-cache:format-yaml +format-yaml

--- a/Earthfile
+++ b/Earthfile
@@ -1,6 +1,18 @@
 VERSION 0.8
 PROJECT jdno/earthly-functions
 
+format-json:
+    ARG FIX="false"
+    DO ./prettier+PRETTIER --EXTENSION="json" --FIX="$FIX"
+
+format-markdown:
+    ARG FIX="false"
+    DO ./prettier+PRETTIER --EXTENSION="md" --FIX="$FIX"
+
+format-yaml:
+    ARG FIX="false"
+    DO ./prettier+PRETTIER --EXTENSION="{yaml,yml}" --FIX="$FIX"
+
 # lint-markdown checks Markdown files for linting errors
 lint-markdown:
     DO ./markdown+LINT
@@ -8,3 +20,7 @@ lint-markdown:
 # lint-yaml checks YAML files for linting errors
 lint-yaml:
     DO ./yaml+LINT
+
+prettier:
+    ARG FIX="false"
+    DO ./prettier+PRETTIER --FIX="$FIX"

--- a/prettier/Earthfile
+++ b/prettier/Earthfile
@@ -1,0 +1,35 @@
+VERSION 0.8
+
+PRETTIER:
+    FUNCTION
+
+    # Optionally specify the file extensions that Prettier should format
+    ARG EXTENSION="*"
+
+    # Format the files and write changes back to the local filesystem
+    ARG FIX="false"
+
+    # Optionally specify the version of Prettier that gets used
+    ARG PRETTIER_VERSION="latest"
+
+    FROM node:alpine
+    WORKDIR /project
+
+    # Install prettier
+    RUN npm install -g prettier@$PRETTIER_VERSION
+
+    # Copy the source code into the container
+    COPY . .
+
+    # Check or fix the formatting of the source code
+    LET flag = "check"
+    IF [ "$FIX" = "true" ]
+        SET flag = "write"
+    END
+
+    RUN prettier --$flag --ignore-unknown "**/*.$EXTENSION"
+
+    # Save changes back to the local filesystem
+    IF [ "$FIX" = "true" ]
+        SAVE ARTIFACT ./* AS LOCAL .
+    END


### PR DESCRIPTION
Prettier has been added as a new Earthly function. It supports various arguments to lock the version, limit Prettier to format certain file types only, and to optionally write the formatted files back to the local filesystem.

The GitHub Actions workflows that format JSON, Markdown, and YAML files have been adjusted to use this new function.